### PR TITLE
make ohmu compatible with Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "2.7"
+  - "3.5"
 script: nosetests --with-coverage --cover-erase --cover-package=ohmu
 before_install:
   pip install codecov

--- a/ohmu/test_fs.py
+++ b/ohmu/test_fs.py
@@ -3,12 +3,15 @@ import shutil
 from contextlib import contextmanager
 from os.path import join
 from tempfile import mkdtemp
+import sys
 
 from mock import Mock, patch
 
 from . import fs
 from .utils import TestCase
 
+if sys.version_info.major == 3:
+    basestring = str
 
 class File(TestCase):
 

--- a/ohmu/test_views.py
+++ b/ohmu/test_views.py
@@ -1,3 +1,5 @@
+import sys
+
 from mock import Mock, patch
 
 from . import fs, views
@@ -213,8 +215,13 @@ class Canvas(TestCase):
         a.add_child(fs.File('b', size=5))
 
         self.assertEqual(len(structure), 1)
-        root = fs.File(structure.keys()[0], is_dir=True, path='/')
-        self.add_recursive(root, structure.values()[0])
+        if sys.version_info.major == 3:
+            # In Python 3 <dict>.keys() does not return a list but <dict_keys>
+            root = fs.File(list(structure.keys())[0], is_dir=True, path='/')
+            self.add_recursive(root, list(structure.values())[0])
+        else:
+            root = fs.File(structure.keys()[0], is_dir=True, path='/')
+            self.add_recursive(root, structure.values()[0])
 
         root.sortAll()
 

--- a/ohmu/utils.py
+++ b/ohmu/utils.py
@@ -1,7 +1,10 @@
 from unittest import TestCase as BaseTestCase
 import re
 import curses
+import sys
 
+if sys.version_info.major == 3:
+    basestring = str
 
 class TestCase(BaseTestCase):
 

--- a/ohmu/views.py
+++ b/ohmu/views.py
@@ -2,7 +2,10 @@ from itertools import chain, repeat
 import curses
 import math
 import os
+import sys
 
+if sys.version_info.major == 3:
+    xrange = range
 
 class Canvas(object):
 


### PR DESCRIPTION
The only issue was the usage of xrange(), which does not exist in Python
3 because range() uses a C-based implementation. This can be solved by
overriding xrange when running under Python 3. Fixes #24.