### PR TITLE
Bug fix for Python 2.6 and earlier: 'tuple' object has no attribute 'major'

### DIFF
--- a/ohmu/views.py
+++ b/ohmu/views.py
@@ -4,7 +4,7 @@ import math
 import os
 import sys
 
-if sys.version_info.major == 3:
+if sys.version_info[0] == 3:
     xrange = range
 
 class Canvas(object):


### PR DESCRIPTION
Python 2.6 and earlier do not have sys.version_info.major since it is just tuple, use sys.version_info[0] instead of sys.version_info.major to support them.